### PR TITLE
Support for severity levels and custom reviewdog flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Action: Run Android Lint with reviewdog
 
-This action runs [Andriod Lint](https://developer.android.com/studio/write/lint) with
+This action runs [Android Lint](https://developer.android.com/studio/write/lint) with
 [reviewdog](https://github.com/reviewdog/reviewdog).
 
 ## Inputs
@@ -23,6 +23,11 @@ The default is `error`.
 
 Optional. Reporter of reviewdog command [`github-check`, `github-pr-check`,`github-pr-review`].
 The default is `github-check`.
+
+#### `reviewdog_flags`
+
+Optional. Additional flags to be passed to reviewdog cli.
+The default is ``.
 
 ## Example usage
 

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,11 @@ inputs:
     required: false
     default: 'github-check'
 
+  reviewdog_flags:
+    description: 'Additional reviewdog flags'
+    required: false
+    default: ''
+
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -31,6 +36,7 @@ runs:
     - ${{ inputs.lint_xml_file }}
     - ${{ inputs.level }}
     - ${{ inputs.reporter }}
+    - ${{ inputs.reviewdog_flags }}
 
 branding:
   icon: 'smartphone'

--- a/converter.py
+++ b/converter.py
@@ -34,7 +34,10 @@ for issue in ET.parse(sys.argv[1]).getroot().iter('issue'):
     else:
         error.attrib['column'] = str(0)
 
-    error.attrib['severity'] = 'error'
+    if 'severity' in issue.attrib:
+        error.attrib['severity'] = issue.attrib['severity']
+    else:
+        error.attrib['severity'] = 'info' 
 
     issueId = issue.attrib['id']
     message = issue.attrib['message']

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,4 +3,4 @@
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 python3 /usr/local/bin/converter.py $GITHUB_WORKSPACE/${INPUT_LINT_XML_FILE}
-cat output_checkstyle.xml | reviewdog -f=checkstyle -name="Android Lint" -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}"
+cat output_checkstyle.xml | reviewdog -f=checkstyle -name="Android Lint" -reporter="${INPUT_REPORTER}" -level="${INPUT_LEVEL}" ${INPUT_REVIEWDOG_FLAGS}


### PR DESCRIPTION
Hi @DVDAndroid,
First of all thank you for developing this Android Lint integration for reviewdog and GitHub Actions. 🚀 

This PR enables the support for passing custom flags to `reviewdog`, as well as passing the severity level of Android Lint issues to reviewdog, useful for displaying the right severity for each issue in the action report.

Succesfully tested both features by integrating the action in a workflow and everything ran smoothly. 👍🏻 